### PR TITLE
Adding log4j appender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 .DS_Store
+.gradle
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,28 @@ In order for this to work, you must have the following environmental variables s
     HONEYBADGER_API_KEY
     JAVA_ENV
 
+If you are using the log4j appender, JAVA_ENV can be set instead in the log4j.properties file.
+
 HONEYBADGER_API_KEY: Contains your Honeybadger api key. This is found in your projects settings on the Honeybadger web page.
 
 JAVA_ENV: Describes the environment where your program is running. I use development and production.
+
+
+log4j appender
+==============
+
+The HoneybadgerAppender is a log4j appender that reports log messages set to the ERROR level to Honeybadger.
+
+To use it, you will need to add a few lines to log4j.properties in addition to the environment variables
+required for the Honeybadger Java client. First, add HoneybadgerAppender as a root appender:
+
+    log4j.rootLogger=INFO, file, console [...], honeybadger
+
+Then set the appender, passing in sys properties if desired:
+
+    log4j.appender.honeybadger=honeybadger.HoneybadgerAppender
+    log4j.appender.honeybadger.Threshold=ERROR
+    log4j.appender.honeybadger.HoneybadgerAPIKey=${api_key}
+    log4j.appender.honeybadger.JavaEnv=${java_env}
+
+Note that, since HoneybadgerAppender instantiates Honeybadger, all uncaught exceptions will *also* be reported to Honeybadger.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'java'
-jar.archiveName = "Honeybadger.jar"
+
+jar {
+  baseName "Honeybadger"
+  version "1.0.2"
+}
 
 sourceSets {
   main {

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
-archivesBaseName = 'honeybadger-java' 
-version = '1.0.9'
-group = 'com.opinionlab.honeybadger'
+jar {
+  baseName "honeybadger"
+  version "1.3.0"
+}
 
 sourceSets {
   main {
@@ -14,11 +15,24 @@ sourceSets {
   }
 }
 
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            groupId 'honeybadger'
+            artifactId 'honeybadger'
+            version '1.3.0'
+
+            from components.java
+        }
+    }
+}
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
     compile 'log4j:log4j:1.2.17', 
-            'com.google.code.gson:gson:2.2.4'
+            'com.google.code.gson:gson:2.2.4',
+            'org.apache.commons:commons-lang3:3.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'java'
+jar.archiveName = "Honeybadger.jar"
+
+sourceSets {
+  main {
+    java {
+      srcDir "src"
+    }
+  }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'log4j:log4j:1.2.17', 
+            'com.google.code.gson:gson:2.2.4'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
-jar {
-  baseName "Honeybadger"
-  version "1.0.2"
-}
+archivesBaseName = 'honeybadger-java' 
+version = '1.0.9'
+group = 'com.opinionlab.honeybadger'
 
 sourceSets {
   main {

--- a/src/honeybadger/HoneybadgerAppender.java
+++ b/src/honeybadger/HoneybadgerAppender.java
@@ -1,0 +1,52 @@
+
+package honeybadger;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.spi.ThrowableInformation;
+
+public class HoneybadgerAppender extends AppenderSkeleton {
+
+  private Honeybadger honeybadger;
+  private String honeybadgerAPIKey;
+  private String javaEnv;
+
+  public String getJavaEnv() {
+    return javaEnv;
+  }
+
+  public void setJavaEnv(String javaEnv) {
+    this.javaEnv = javaEnv;
+  }
+
+
+  public String getHoneybadgerAPIKey() {
+    return honeybadgerAPIKey;
+  }
+
+  public void setHoneybadgerAPIKey(String key) {
+    honeybadgerAPIKey = key;
+  }
+
+  @Override
+  protected void append(LoggingEvent event) {
+    ThrowableInformation errorInfo = event.getThrowableInformation();
+    honeybadger.reportErrorToHoneyBadger(errorInfo == null ?
+        new Exception(event.getRenderedMessage()) :
+        errorInfo.getThrowable());
+  }
+
+  @Override
+  public void close() {
+    honeybadger.close();
+  }
+
+  @Override
+  public boolean requiresLayout() {
+    return false;
+  }
+
+  public void activateOptions() {
+    honeybadger = new Honeybadger(honeybadgerAPIKey, javaEnv, false);
+  }
+}


### PR DESCRIPTION
We added a log4j appender that reports logged errors to Honeybadger, as well as adding a build.gradle file. (The fork seems more heavyweight than we need, so we just built on the original repo -- thanks for the pointer though!) We ended up doing some refactoring of the original class, too, but it should all be backwards-compatible.

Before deploying to Maven Central probably the group ID should be changed to something guaranteed to be unique.